### PR TITLE
Adding support for a tfvars file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,8 @@ inputs:
     default: '.'
   sarif_file:
     description: The path to write the sarif report, defaults to tfsec.sarif
+  tfvars_file:
+    description: The tfvars file to use for the scan
 outputs:
   tfsec-return-code:
     description: 'tfsec command return code'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,17 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
 
+if [ -n "${INPUT_TFVARS_FILE}" ]; then
+   echo "::debug::Using tfvars file ${INPUT_TFVARS_FILE}"
+   TFVARS_OPTION="--tfvars-file ${INPUT_TFVARS_FILE}"
+fi
+
 echo {} > ${INPUT_SARIF_FILE}
 
-tfsec --format=sarif "${INPUT_WORKING_DIRECTORY}" > ${INPUT_SARIF_FILE}
+tfsec --format=sarif "${INPUT_WORKING_DIRECTORY}" ${TFVARS_OPTION} > ${INPUT_SARIF_FILE}
 
 tfsec_return="${PIPESTATUS[0]}" exit_code=$?
 
 echo ::set-output name=tfsec-return-code::"${tfsec_return}"
+
+


### PR DESCRIPTION
The [SARIF upload currently fails](https://github.com/octodemo/OctoTerraform/runs/2773377497?check_suite_focus=true#step:6:9) with the message 👇  when using variables defined in a tfvars file during a scan. It seems like [a warning is appended to the JSON file](https://github.com/octodemo/OctoTerraform/runs/2773377497?check_suite_focus=true#step:5:5). The real solution would probably to avoid sending warnings on stdout, but supporting `tfvars` is also useful and does the trick for me. 

```
Processing sarif files: ["tfsec.sarif"]
  Error: Unexpected token  in JSON at position 0
  SyntaxError: Unexpected token  in JSON at position 0
      at JSON.parse (<anonymous>)
      at validateSarifFileSchema (/home/runner/work/_actions/github/codeql-action/v1/lib/upload-lib.js:170:24)
      at uploadFiles (/home/runner/work/_actions/github/codeql-action/v1/lib/upload-lib.js:243:9)
      at Object.uploadFromActions (/home/runner/work/_actions/github/codeql-action/v1/lib/upload-lib.js:119:18)
      at async run (/home/runner/work/_actions/github/codeql-action/v1/lib/upload-sarif-action.js:37:29)
      at async runWrapper (/home/runner/work/_actions/github/codeql-action/v1/lib/upload-sarif-action.js:49:9)
```